### PR TITLE
fix: fix layout of FeaturedChannelsRow (#14)

### DIFF
--- a/Podcast-CloneCoding/Podcast-CloneCoding/View/FeaturedChannels/FeaturedChannelsItem.swift
+++ b/Podcast-CloneCoding/Podcast-CloneCoding/View/FeaturedChannels/FeaturedChannelsItem.swift
@@ -21,6 +21,7 @@ struct FeaturedChannelsItem: View {
                 Spacer(minLength: 15)
                 Text(featuredChannel.detail)
                     .multilineTextAlignment(.center)
+                    .lineLimit(3)
                     .font(.subheadline)
                     .foregroundColor(.white)
                 Spacer(minLength: 15)

--- a/Podcast-CloneCoding/Podcast-CloneCoding/View/FeaturedChannels/FeaturedChannelsItem.swift
+++ b/Podcast-CloneCoding/Podcast-CloneCoding/View/FeaturedChannels/FeaturedChannelsItem.swift
@@ -11,16 +11,23 @@ struct FeaturedChannelsItem: View {
     var featuredChannel: FeaturedChannel
     
     var body: some View {
-        VStack(alignment: .trailing, spacing: 0) {
+        VStack(alignment: .center, spacing: 0) {
             Image(featuredChannel.thumbnail)
                 .resizable()
                 .scaledToFill()
+                .frame(height: 245)
+                .clipped()
+            HStack(alignment: .center) {
+                Spacer(minLength: 15)
                 Text(featuredChannel.detail)
                     .multilineTextAlignment(.center)
                     .font(.subheadline)
                     .foregroundColor(.white)
-                    .frame(height: 100)
+                Spacer(minLength: 15)
+            }
+            .frame(height: 85)
         }
+        .frame(width: 250, height: 330)
         .background(featuredChannel.themeColor)
     }
 }

--- a/Podcast-CloneCoding/Podcast-CloneCoding/View/FeaturedChannels/FeaturedChannelsRow.swift
+++ b/Podcast-CloneCoding/Podcast-CloneCoding/View/FeaturedChannels/FeaturedChannelsRow.swift
@@ -28,7 +28,7 @@ struct FeaturedChannelsRow: View {
                         Spacer()
                         ForEach(featuredChannels) { featuredChannel in
                             FeaturedChannelsItem(featuredChannel: featuredChannel)
-                                .frame(width: 250, height: 350, alignment: .leading)
+                                .frame(width: 250, height: 330, alignment: .leading)
                                 .border(.gray, width: 0.2)
                                 .cornerRadius(10)
                                 .shadow(color: .black.opacity(0.2), radius: 3, x: 0, y: 2)


### PR DESCRIPTION
- _**🥫Podcast Clone Coding**_

## 📢 Contents
- fix text padding
- fix text parent view height

## 💡Note
- Layout need padding, but padding is too big so use `Spacer` with `minLength` parameter

```swift
HStack(alignment: .center) {
    Spacer(minLength: 15)
      Text(featuredChannel.detail)
        .multilineTextAlignment(.center)
        .lineLimit(3)
        .font(.subheadline)
        .foregroundColor(.white)
    Spacer(minLength: 15)
}
```
> close #14
