### PR TITLE
feat: make New&Noteworthy detail view and apply ContextMenu (#24)

### DIFF
--- a/Podcast-CloneCoding/Podcast-CloneCoding/View/NewNoteworthy/NewNoteworthyDetail.swift
+++ b/Podcast-CloneCoding/Podcast-CloneCoding/View/NewNoteworthy/NewNoteworthyDetail.swift
@@ -8,13 +8,78 @@
 import SwiftUI
 
 struct NewNoteworthyDetail: View {
+//    init(newNoteworthy: NewNoteworthy) {
+//        self.newNoteworthy = newNoteworthy
+//        UINavigationBar.appearance().backgroundColor = .clear
+//    }
+    
+    // MARK: - Properties
+    
+    var newNoteworthy: NewNoteworthy
+    
+    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    @GestureState private var dragOffset = CGSize.zero
+    
+    // MARK: - View Life Cycle
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        if #available(iOS 15.0, *) {
+            List {
+                VStack {
+                    Color(red: 0, green: 100, blue: 0 )
+                        .frame(height: 500)
+                }
+                .listRowSeparator(.hidden)
+            }
+            .listStyle(.plain)
+            .refreshable {
+                print("refreshable")
+            }
+//            .edgesIgnoringSafeArea(.top)
+            .navigationTitle(newNoteworthy.title)
+            .navigationBarBackButtonHidden(true)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: {
+                        presentationMode.wrappedValue.dismiss()
+                    }, label: {
+                        Image(systemName: "chevron.backward.circle.fill")
+                    })
+                }
+                
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    Button(action: {
+                        
+                    }, label: {
+                        Image(systemName: "plus.circle.fill")
+                    })
+                    
+                    Button(action: {
+                        
+                    }, label: {
+                        Image(systemName: "ellipsis.circle.fill")
+                    })
+                }
+            }
+            .gesture(DragGesture().updating($dragOffset, body: { (value, state, transaction) in
+                if(value.startLocation.x < 20 && value.translation.width > 100) {
+                    self.presentationMode.wrappedValue.dismiss()
+                }
+            }))
+            .foregroundColor(.gray)
+        } else {
+            // Fallback on earlier versions
+        }
     }
 }
 
+// MARK: - Previews
+
 struct NewNoteworthyDetail_Previews: PreviewProvider {
+    static let newNoteworthys = ModelData().newNoteworthy
+    
     static var previews: some View {
-        NewNoteworthyDetail()
+        NewNoteworthyDetail(newNoteworthy: newNoteworthys[0])
     }
 }

--- a/Podcast-CloneCoding/Podcast-CloneCoding/View/NewNoteworthy/NewNoteworthyItem.swift
+++ b/Podcast-CloneCoding/Podcast-CloneCoding/View/NewNoteworthy/NewNoteworthyItem.swift
@@ -27,6 +27,7 @@ struct NewNoteworthyItem: View {
                     .stroke(Color.secondary, lineWidth: 0.2))
             Text(newNoteworthy.title)
                 .font(.subheadline)
+                .foregroundColor(.black)
                 .lineLimit(1)
             Text(newNoteworthy.caster)
                 .font(.subheadline)
@@ -34,6 +35,7 @@ struct NewNoteworthyItem: View {
                 .lineLimit(1) 
         }
         .frame(width: 160, height: 210, alignment: .topLeading)
+        .background(Color.white)
     }
 }
 

--- a/Podcast-CloneCoding/Podcast-CloneCoding/View/NewNoteworthy/NewNoteworthyRow.swift
+++ b/Podcast-CloneCoding/Podcast-CloneCoding/View/NewNoteworthy/NewNoteworthyRow.swift
@@ -33,29 +33,28 @@ struct NewNoteworthyRow: View {
                 HStack(alignment: .top, spacing: 12) {
                     Spacer()
                     ForEach(newNoteworthys) { newNoteworthy in
-                        // TODO: - link to NewNoteworthyDetail view.
-//                        NavigationLink {
-//                            NewNoteworthyDetail()
-//                        } label: {
+                        NavigationLink {
+                            NewNoteworthyDetail(newNoteworthy: newNoteworthy)
+                        } label: {
                             NewNoteworthyItem(newNoteworthy: newNoteworthy)
-//                        }
-                            .contextMenu {
-                                Button(action: {}) {
-                                    Label("Follow Show", systemImage: "plus.circle")
-                                }
-                                Button(action: {}) {
-                                    Label("Go to Show", systemImage: "airplayaudio")
-                                }
-                                Button(action: {}) {
-                                    Label("Share Show", systemImage: "square.and.arrow.up")
-                                }
-                                Button(action: {}) {
-                                    Label("Copy Link", systemImage: "link")
-                                }
-                                Button(action: {}) {
-                                    Label("Report a Concern", systemImage: "exclamationmark.bubble")
-                                }
+                        }
+                        .contextMenu {
+                            Button(action: {}) {
+                                Label("Follow Show", systemImage: "plus.circle")
                             }
+                            Button(action: {}) {
+                                Label("Go to Show", systemImage: "airplayaudio")
+                            }
+                            Button(action: {}) {
+                                Label("Share Show", systemImage: "square.and.arrow.up")
+                            }
+                            Button(action: {}) {
+                                Label("Copy Link", systemImage: "link")
+                            }
+                            Button(action: {}) {
+                                Label("Report a Concern", systemImage: "exclamationmark.bubble")
+                            }
+                        }
                     }
                     Spacer()
                 }

--- a/Podcast-CloneCoding/Podcast-CloneCoding/View/Tab/Browse.swift
+++ b/Podcast-CloneCoding/Podcast-CloneCoding/View/Tab/Browse.swift
@@ -46,7 +46,6 @@ struct Browse: View {
 //                    PodcastsQuickLinksRow()
                 }
             }
-            .listStyle(.inset)
             .navigationTitle("Browse")
         }
     }


### PR DESCRIPTION
_**🥫Podcast Clone Coding**_

## 📢 Contents
- simply materialize `NewNoteworthyDetail` view

## 💡Note
- set navigation bar.
- set refresh control(in SwiftUI its called `refreshable` modifier)

## 📸 Screen Shot
<img src="https://user-images.githubusercontent.com/69136340/170031971-bf98820e-c698-42e6-ad75-45448ad5ef76.png" width ="200">

> close #24

